### PR TITLE
feat: add erpc as rpc proxy and caching tool for wvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ code erpc.yaml
 docker-compose up -d
 ```
 
-Finally, you can set eRPC's proxy URL in each relative network config
+Finally, you can set eRPC's proxy URL in each relative network config.
 ```optimism.json
 {
     "name": "Optimism",

--- a/README.md
+++ b/README.md
@@ -50,6 +50,30 @@ To start archiving your network block data on WeaveVM:
 5. Choose a unique `archive_pool_address` that's different from your `archiver_address`.
 6. Set up your PlanetScale DB according to `db_schema.sql`.
 
+### RPC Proxy and Caching
+
+You can use [eRPC](https://github.com/erpc/erpc) to cache, load-balance and failover between as many RPC endpoints and use eRPC's proxy URL in each network's config for WeaveVM. This will increase performance and resilliency and reduce RPC usage cost while fetching network's block data via WeaveVM.
+
+```
+#1  modify erpc.yaml
+cp erpc.yaml.dist erpc.yaml
+code erpc.yaml
+
+#2  run docker-compose
+docker-compose up -d
+```
+
+Finally, you can set eRPC's proxy URL in each relative network config
+```optimism.json
+{
+    "name": "Optimism",
+    "network_chain_id": 10,
+    "network_rpc": "http://erpc:4000/main/evm/10",
+    ...
+}
+```
+
+
 ## How it works
 
 The WeaveVM Archiver node operates as follows:

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ To start archiving your network block data on WeaveVM:
 
 You can use [eRPC](https://github.com/erpc/erpc) to cache, load-balance and failover between as many RPC endpoints and use eRPC's proxy URL in each network's config for WeaveVM. This will increase performance and resilliency and reduce RPC usage cost while fetching network's block data via WeaveVM.
 
-```
-// modify erpc.yaml
+```bash
+# modify erpc.yaml
 cp erpc.yaml.dist erpc.yaml
 code erpc.yaml
 
-// run docker-compose
+# run docker-compose
 docker-compose up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ To start archiving your network block data on WeaveVM:
 You can use [eRPC](https://github.com/erpc/erpc) to cache, load-balance and failover between as many RPC endpoints and use eRPC's proxy URL in each network's config for WeaveVM. This will increase performance and resilliency and reduce RPC usage cost while fetching network's block data via WeaveVM.
 
 ```
-// #1  modify erpc.yaml
+// modify erpc.yaml
 cp erpc.yaml.dist erpc.yaml
 code erpc.yaml
 
-// #2  run docker-compose
+// run docker-compose
 docker-compose up -d
 ```
 
@@ -69,7 +69,7 @@ Finally, you can set eRPC's proxy URL in each relative network config
     "name": "Optimism",
     "network_chain_id": 10,
     "network_rpc": "http://erpc:4000/main/evm/10",
-    // ...
+    ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ To start archiving your network block data on WeaveVM:
 You can use [eRPC](https://github.com/erpc/erpc) to cache, load-balance and failover between as many RPC endpoints and use eRPC's proxy URL in each network's config for WeaveVM. This will increase performance and resilliency and reduce RPC usage cost while fetching network's block data via WeaveVM.
 
 ```
-#1  modify erpc.yaml
+// #1  modify erpc.yaml
 cp erpc.yaml.dist erpc.yaml
 code erpc.yaml
 
-#2  run docker-compose
+// #2  run docker-compose
 docker-compose up -d
 ```
 
@@ -69,7 +69,7 @@ Finally, you can set eRPC's proxy URL in each relative network config
     "name": "Optimism",
     "network_chain_id": 10,
     "network_rpc": "http://erpc:4000/main/evm/10",
-    ...
+    // ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To start archiving your network block data on WeaveVM:
 
 ### RPC Proxy and Caching
 
-You can use [eRPC](https://github.com/erpc/erpc) to cache, load-balance and failover between as many RPC endpoints and use eRPC's proxy URL in each network's config for WeaveVM. This will increase performance and resilliency and reduce RPC usage cost while fetching network's block data via WeaveVM.
+You can use [eRPC](https://github.com/erpc/erpc) to cache, load-balance and failover between as many RPC endpoints and use eRPC's proxy URL in each network's config for WeaveVM. This will increase performance and resiliency and reduce RPC usage cost while fetching network's block data via WeaveVM.
 
 ```bash
 # modify erpc.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,24 +12,4 @@ services:
       - "${PWD}/erpc.yaml:/root/erpc.yaml"
     ports:
       - "4000:4000"
-      - "4001:4001"
     restart: always
-
-  monitoring:
-    build: ./monitoring
-    ports:
-      - "3000:3000" # Grafana
-      - "9090:9090" # Prometheus
-    environment:
-      - SERVICE_ENDPOINT=host.docker.internal
-      - SERVICE_PORT=4001
-    volumes:
-      - ./monitoring/prometheus:/etc/prometheus
-      - ./monitoring/grafana/grafana.ini:/etc/grafana/grafana.ini
-      - ./monitoring/grafana/dashboards:/etc/grafana/dashboards
-      - prometheus_data:/prometheus
-      - grafana_data:/var/lib/grafana
-
-volumes:
-  prometheus_data:
-  grafana_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3"
+
+networks:
+  erpc:
+    driver: bridge
+
+services:
+  erpc:
+    image: ghcr.io/erpc/erpc:latest
+    platform: linux/amd64
+    volumes:
+      - "${PWD}/erpc.yaml:/root/erpc.yaml"
+    ports:
+      - "4000:4000"
+      - "4001:4001"
+    restart: always
+
+  monitoring:
+    build: ./monitoring
+    ports:
+      - "3000:3000" # Grafana
+      - "9090:9090" # Prometheus
+    environment:
+      - SERVICE_ENDPOINT=host.docker.internal
+      - SERVICE_PORT=4001
+    volumes:
+      - ./monitoring/prometheus:/etc/prometheus
+      - ./monitoring/grafana/grafana.ini:/etc/grafana/grafana.ini
+      - ./monitoring/grafana/dashboards:/etc/grafana/dashboards
+      - prometheus_data:/prometheus
+      - grafana_data:/var/lib/grafana
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/erpc.yaml.dist
+++ b/erpc.yaml.dist
@@ -1,0 +1,124 @@
+logLevel: warn
+database:
+  evmJsonRpcCache:
+    driver: memory
+    # driver: postgresql
+    # postgresql:
+    #   connectionUri: >-
+    #     postgres://YOUR_USERNAME_HERE:YOUR_PASSWORD_HERE@your.postgres.hostname.here.com:5432/your_database_name
+    #   table: rpc_cache
+server:
+  httpHost: 0.0.0.0
+  httpPort: 4000
+metrics:
+  enabled: true
+  host: 0.0.0.0
+  port: 4001
+projects:
+  - id: main
+    networks:
+      - architecture: evm
+        evm:
+          chainId: 1
+        failsafe:
+          timeout:
+            duration: 30s
+          retry:
+            maxCount: 3
+            delay: 500ms
+            backoffMaxDelay: 10s
+            backoffFactor: 0.3
+            jitter: 500ms
+          hedge:
+            delay: 3000ms
+            maxCount: 2
+      - architecture: evm
+        evm:
+          chainId: 42161
+        failsafe:
+          timeout:
+            duration: 30s
+          retry:
+            maxCount: 5
+            delay: 500ms
+            backoffMaxDelay: 10s
+            backoffFactor: 0.3
+            jitter: 200ms
+          hedge:
+            delay: 1000ms
+            maxCount: 2
+    upstreams:
+      - id: alchemy-multi-chain-example-1
+        endpoint: alchemy://XXXX_YOUR_ALCHEMY_API_KEY_HERE_XXXX
+        rateLimitBudget: global
+        failsafe:
+          timeout:
+            duration: 15s
+          retry:
+            maxCount: 2
+            delay: 1000ms
+            backoffMaxDelay: 10s
+            backoffFactor: 0.3
+            jitter: 500ms
+      - id: blastapi-chain-42161
+        type: evm
+        endpoint: https://arbitrum-one.blastapi.io/xxxxxxx-xxxxxx-xxxxxxx
+        rateLimitBudget: global-blast
+        evm:
+          chainId: 42161
+        failsafe:
+          timeout:
+            duration: 15s
+          retry:
+            maxCount: 2
+            delay: 1000ms
+            backoffMaxDelay: 10s
+            backoffFactor: 0.3
+            jitter: 500ms
+      - id: blastapi-chain-1
+        type: evm
+        endpoint: https://eth-mainnet.blastapi.io/xxxxxxx-xxxxxx-xxxxxxx
+        rateLimitBudget: global-blast
+        evm:
+          chainId: 1
+        failsafe:
+          timeout:
+            duration: 15s
+          retry:
+            maxCount: 2
+            delay: 1000ms
+            backoffMaxDelay: 10s
+            backoffFactor: 0.3
+            jitter: 500ms
+      - id: quiknode-chain-42161
+        type: evm
+        endpoint: https://xxxxxx-xxxxxx.arbitrum-mainnet.quiknode.pro/xxxxxxxxxxxxxxxxxxxxxxxx/
+        rateLimitBudget: global-quicknode
+        evm:
+          chainId: 42161
+        failsafe:
+          timeout:
+            duration: 15s
+          retry:
+            maxCount: 2
+            delay: 1000ms
+            backoffMaxDelay: 10s
+            backoffFactor: 0.3
+            jitter: 500ms
+rateLimiters:
+  budgets:
+    - id: default-budget
+      rules:
+        - method: '*'
+          maxCount: 10000
+          period: 1s
+    - id: global-blast
+      rules:
+        - method: '*'
+          maxCount: 1000
+          period: 1s
+    - id: global-quicknode
+      rules:
+        - method: '*'
+          maxCount: 300
+          period: 1s


### PR DESCRIPTION
Using eRPC will increase performance and resiliency and reduce RPC usage cost while fetching network's block data via WeaveVM.

![Screenshot 2024-08-16 at 08 50 40](https://github.com/user-attachments/assets/bbb32156-ecf8-4b80-b6d1-79e82229625f)
